### PR TITLE
[WIP] Feature: example support

### DIFF
--- a/src/__tests__/data/agrees-post.ts
+++ b/src/__tests__/data/agrees-post.ts
@@ -25,8 +25,8 @@ enum GenderType {
 
 export type CreateRequestBody = {
   /**
-   * @pattern [A-Z]+
-   * @examples a
+   * @pattern ^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$
+   * @examples foo@example.com
    */
   email: string;
   /**

--- a/src/__tests__/data/agrees-post.ts
+++ b/src/__tests__/data/agrees-post.ts
@@ -26,10 +26,12 @@ enum GenderType {
 export type CreateRequestBody = {
   /**
    * @pattern [A-Z]+
+   * @examples a
    */
   email: string;
   /**
    * @maximum 1000
+   * @examples 5
    * @minimum 0
    */
   id: Placeholder<number>;

--- a/src/generate-swagger.ts
+++ b/src/generate-swagger.ts
@@ -10,7 +10,7 @@ export function generateSwagger(
   disablePathNumber
 ) {
   const swagger = {
-    openapi: "3.0.0",
+    swagger: "2.0",
     info: {
       title,
       description,


### PR DESCRIPTION
# About

- support `@examples` Annotation in request body type definition.

You can use API client in swagger-ui with example parameters, if merged this patch.
